### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var sass = require("node-sass"),
-  ent = require("ent"),
+  he = require("he"),
   marked = require("marked"),
   typogr = require("typogr"),
   classesRegex = "[a-zA-Z0-9 _\\-]+";
@@ -105,7 +105,7 @@ exports.parseMarkdown = function (markdown) {
   markup = parser.parse(tokens);
 
   // decode html entities as typogr misses them otherwise
-  markup = ent.decode(markup);
+  markup = he.decode(markup);
 
   // typographic fanciness
   markup = typogr.typogrify(markup);

--- a/package.json
+++ b/package.json
@@ -18,21 +18,21 @@
     "apocalism": "./bin/apocalism-cli.js"
   },
   "dependencies": {
-    "typogr": "0.6.x",
-    "hypher": "0.2.x",
-    "ent": "0.1.x",
-    "commander": "2.1.x",
-    "node-sass": "0.8.x",
-    "gm": "1.14.x",
-    "json2sass": "https://github.com/renancouto/json2sass/tarball/bb192bd3984cad70eae2424ed5fa4ec2dc0d36d0",
-    "case": "1.0.x",
-    "async": "0.2.x",
-    "fs-extra": "0.8.x",
-    "handlebars": "2.0.x",
     "arg-err": "0.0.x",
+    "async": "0.2.x",
+    "case": "1.0.x",
+    "commander": "2.1.x",
+    "fs-extra": "0.8.x",
+    "gm": "1.14.x",
+    "handlebars": "2.0.x",
+    "he": "0.4.x",
+    "hypher": "0.2.x",
+    "json2sass": "https://github.com/renancouto/json2sass/tarball/bb192bd3984cad70eae2424ed5fa4ec2dc0d36d0",
     "marked": "0.3.x",
+    "node-sass": "0.8.x",
     "phantomjs": "1.9.7-1",
-    "socket.io": "~0.9.16"
+    "socket.io": "~0.9.16",
+    "typogr": "0.6.x"
   },
   "devDependencies": {
     "mocha": "1.17.x",


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](http://mths.be/he).
